### PR TITLE
Hide contents section in mobile

### DIFF
--- a/static/styles/_shared_layout.less
+++ b/static/styles/_shared_layout.less
@@ -614,7 +614,7 @@ body:not(.donejs):not(.community) {
 			}
 		}
 		section.contents {
-			display: none;
+			display: none !important;
 			left: 0px;
 			max-height: ~"calc( 100% - 100px )";
 			overflow-y: scroll; /* has to be scroll, not auto */


### PR DESCRIPTION
The bit-docs-html-toc sets the container element's display to "block" once it has finished rendering its template. This overrides the display "none" set in the CSS files. Adding !important to the rule fixes the issue

mobile
![127 0 0 1-8080-site-place-my-order html ipad](https://cloud.githubusercontent.com/assets/724877/22886554/9f098dd4-f1bb-11e6-9461-6b1228eba97d.png)

desktop
![google chrome](https://cloud.githubusercontent.com/assets/724877/22886557/a8f3763e-f1bb-11e6-98df-7e69e1bbaba0.png)

Closes #25