### PR TITLE
Display mobile TOC correctly

### DIFF
--- a/static/styles/_shared_layout.less
+++ b/static/styles/_shared_layout.less
@@ -621,7 +621,7 @@ body:not(.donejs):not(.community) {
 			-webkit-overflow-scrolling: touch;
 			z-index: 1078;
 			&.active {
-				display: block;
+				display: block !important;
 				width: 100%;
 			}
 			a {


### PR DESCRIPTION
The previous change caused the TOC to be hidden when the menu was "opened" by the user.

![kapture 2017-02-13 at 8 15 33](https://cloud.githubusercontent.com/assets/724877/22888927/a51d1f48-f1c4-11e6-97c4-30e90972af0a.gif)

Closes #25