### PR TITLE
Fixes understated em tags

### DIFF
--- a/static/styles/typography.less
+++ b/static/styles/typography.less
@@ -98,7 +98,7 @@ strong, b {
 }
 em,cite{
 	font-style:italic;
-	font-weight:600;
+	font-weight:400;
 }
 em em,cite cite{
 	font-style:normal;

--- a/static/styles/typography.less
+++ b/static/styles/typography.less
@@ -98,6 +98,7 @@ strong, b {
 }
 em,cite{
 	font-style:italic;
+	font-weight:600;
 }
 em em,cite cite{
 	font-style:normal;


### PR DESCRIPTION
`em` tags now match the weight of `strong` tags.
![image](https://cloud.githubusercontent.com/assets/6282922/25298905/8e064914-26ae-11e7-94bb-c5a4d6a6920b.png)
