### PR TITLE
Add styles to advertise the community survey

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "can": "2.3.28",
+    "donejs-survey-ad": "^0.1.1",
     "dotdotdot": "^1.7.0",
     "jquery": "2.2.4",
     "lodash.debounce": "^4.0.8"

--- a/static/static.js
+++ b/static/static.js
@@ -1,6 +1,7 @@
 var $ = require("jquery");
 var handlePageAnchors = require("./handle-page-anchors");
 var debounce = require('lodash.debounce');
+var SurveyAdControl = require("donejs-survey-ad");
 require("./js/collapse");
 require("./js/dropdown");
 require("./js/tooltip");
@@ -584,6 +585,14 @@ $(function() {
       }
     }, 200);
   }
+});
+
+// Survey ad code
+$(function() {
+  // Set up the survey ad control
+  var surveyAdControl = new SurveyAdControl("survey-ad");
+	// Notify the survey ad control that the user loaded a page
+	surveyAdControl.didEngage();
 });
 
 $("#bithub-events-embed").upcomingEvents({

--- a/static/styles/_header_nav.less
+++ b/static/styles/_header_nav.less
@@ -6,8 +6,15 @@ header {
     height: auto;
   }
   .navbar-default{
-    background-color: rgba( 255, 255, 255, 0.87 );
+    background-color: @headerBackground;
     box-shadow: 0px 3px 5px fade( #CCCCCC, 50% );
+
+    @supports (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px)) {
+  		-webkit-backdrop-filter: @headerBlur;
+  		-webkit-font-smoothing: subpixel-antialiased;
+  		backdrop-filter: @headerBlur;
+    }
+
   }
   .navbar-fixed-top {
     z-index: 1080;

--- a/static/styles/_shared_layout.less
+++ b/static/styles/_shared_layout.less
@@ -269,7 +269,7 @@ body:not(.donejs):not(.community) {
 	/* left navigation */
 	section.contents {
 		position: fixed;
-		z-index: 5;
+		z-index: @table-of-contents-z-index;
 		top: 100px;
 		left: ~"calc( ( 100% - " @containerWidth ~" ) / 2 )";
 		width: 250px;

--- a/static/styles/_survey.less
+++ b/static/styles/_survey.less
@@ -5,6 +5,10 @@
 body.survey:not(.other) {
 	.no-sidebar-page-body;
 
+	survey-ad {
+		display: none;
+	}
+
 	section.title .heading h1 {
 		font-size: 75px;
 		font-weight: 300;

--- a/static/styles/styles.less
+++ b/static/styles/styles.less
@@ -22,6 +22,7 @@
 @import '_misc_sitewide.less';
 @import '_animation.less';
 @import '_lazy-youtube.less';
+@import 'survey-ad.less';
 
 //files for the home page "body.donejs"
 @import '_donejs-typography.less';

--- a/static/styles/survey-ad.less
+++ b/static/styles/survey-ad.less
@@ -1,0 +1,31 @@
+survey-ad {
+  background-color: @headerBackground;
+  box-shadow: 0px -3px 5px fade( #CCCCCC, 50% );
+  font-size: 1.5rem;
+  z-index: @table-of-contents-z-index - 1;// Display under the left nav
+
+  a {
+    color: inherit;
+  }
+
+  .close {
+    color: inherit;
+    cursor: pointer;
+    font-size: 2rem;
+  }
+  .close:hover {
+    background-color: transparent;
+  }
+
+  @supports (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px)) {
+		-webkit-backdrop-filter: @headerBlur;
+		backdrop-filter: @headerBlur;
+  }
+}
+
+// Hide this component on mobile
+@media screen and (max-width: @contentWidth) {
+  survey-ad {
+    display: none;
+  }
+}

--- a/static/styles/variables.less
+++ b/static/styles/variables.less
@@ -49,6 +49,8 @@
 @sidebarBackground: @haze;
 @colorTags: @darkSkies;
 @footerHeight: 80px;
+@headerBackground: rgba(255, 255, 255, 0.87);
+@headerBlur: saturate(180%) blur(20px);
 @headerHeight: 54px;
 @colorParamsReturns: @darkSkies;
 
@@ -107,3 +109,5 @@
 
 @containerWidth: 1000px;
 @contentWidth: 700px;
+
+@table-of-contents-z-index: 5;

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -124,3 +124,4 @@ rendering the "regular" content }}
 	</div>
 	{{/unless}}
 {{/ifEqual}}
+{{> survey-ad.mustache}}

--- a/templates/survey-ad.mustache
+++ b/templates/survey-ad.mustache
@@ -1,0 +1,8 @@
+<survey-ad>
+  <button aria-label="Close" class="close" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <a href="https://donejs.com/survey.html">
+    Help us improve DoneJS by taking our community survey
+  </a>
+</survey-ad>


### PR DESCRIPTION
Similar to how the survey ad works on canjs.com, the control shows up at the bottom of the viewport after the user has visited three pages (ever). There’s an X button to close it, but otherwise the entire bar is a link to the survey landing page. The bar shows up on every single page except the survey page itself.

The bar shows on top of most content but under the left navigation. It does not show up on mobile.

<img width="1059" alt="screen shot 2017-09-24 at 6 07 15 pm" src="https://user-images.githubusercontent.com/10070176/30819019-3c4711fe-a1d2-11e7-8153-497c98b117b6.png">
