### PR TITLE
Hide the survey-ad’s box-shadow when it’s “hidden”

### DIFF
--- a/static/styles/survey-ad.less
+++ b/static/styles/survey-ad.less
@@ -1,5 +1,6 @@
 survey-ad {
   background-color: @headerBackground;
+  bottom: -3.7rem;// 3 rem + a little bit for the box shadow
   box-shadow: 0px -3px 5px fade( #CCCCCC, 50% );
   font-size: 1.5rem;
   z-index: @table-of-contents-z-index - 1;// Display under the left nav


### PR DESCRIPTION
The box-shadow was visible in the viewport because the control wasn’t off-screen enough.

Before:
![localhost-8080-](https://user-images.githubusercontent.com/10070176/30821913-d5dc2d32-a1db-11e7-9bfc-d9bf3e11e2a2.png)

After:
![localhost-8080- 1](https://user-images.githubusercontent.com/10070176/30821923-dcddf8ea-a1db-11e7-810a-21bffe489108.png)
