### PR TITLE
Remove assign

### DIFF
--- a/bit-docs.js
+++ b/bit-docs.js
@@ -1,14 +1,10 @@
 var path = require("path");
-var assign = require("./assign");
 
 module.exports = function(bitDocs) {
   var pkg = require("./package.json");
 
   var dependencies = {};
   dependencies[pkg.name] = pkg.version;
-
-  // add theme dependencies
-  assign(dependencies, pkg.dependencies);
 
   bitDocs.register("html", {
     templates: path.join(__dirname, "templates"),


### PR DESCRIPTION
Stops using `assign` on `dependencies` in `bit-docs.js`.

Can be merged in tandem with https://github.com/donejs/donejs/pull/1030 that updates `donejs/donejs` to `bit-docs-generate-html@0.8.0` b/c when that is merged the `assign` can be dropped here.

Should release as `bit-docs-donejs-theme@2.0.0` after merging if it really does break backwards compatibility. For example, this change may break backward compatibility with older versions of `bit-docs-generate-html` that used an older version of Steal.