### PR TITLE
Allow Community links to work on mobile

### DIFF
--- a/static/styles/_community.less
+++ b/static/styles/_community.less
@@ -61,7 +61,8 @@ body.community {
 		}
 	}
 	.overview-nav {
-		padding-top: 60px;
+		margin-top: 60px;
+    padding-top: 0;
 		.overview-nav-fixed-btn {
 			display: none;
 		}


### PR DESCRIPTION
Fixes https://github.com/donejs/donejs/issues/928

The solution was to use a margin instead of padding so that the container will not overlap the links.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
